### PR TITLE
Removes two autoconf warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 AM_CFLAGS = -I$(srcdir)/include
+ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = lib src . tests 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_INIT([polypasswordhasher], [1.1], [torresariass@gmail.com])
 
 # place to put some extra build scripts installed
 AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_MACRO_DIR([m4])
 
 # fairly severe build strictness
 # change foreign to gnu or gnits to comply with gnu standards


### PR DESCRIPTION
Specifically, we are removing the "consider adding
AC_CONFIG_MACRO_DIR([m4])" and the "consider adding -I m4 to
ACLOCAL_AMFLAGS" warnings when autoreconf --install is called.